### PR TITLE
名前なしイメージをリストから除去

### DIFF
--- a/app/models/joad_image.rb
+++ b/app/models/joad_image.rb
@@ -12,7 +12,9 @@ class JoadImage
     end
 
     def convert(docker_image)
-      docker_image.info['RepoTags'].map do |rt|
+      repo_tags = docker_image.info['RepoTags']
+      repo_tags.delete('<none>:<none>')
+      repo_tags.map do |rt|
         repository, tag = rt.split(':')
         params = {
           repository: repository,


### PR DESCRIPTION
#35

名前のないイメージの詳細画面を開くことができないので、イメージのリストから除去した。
