### PR TITLE
イメージのパスをIDに変更

### DIFF
--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -29,12 +29,12 @@
       <%- @images.each do |image| %>
       <tr>
         <td><span class="glyphicon glyphicon-picture" aria-hidden="true"></span></td>
-        <td><%= link_to image.short_id, images_show_path(repository: u(image.repository), tag: u(image.tag)) %></td>
+        <td><%= link_to image.short_id, images_show_path(id: image.short_id, repository: image.repository, tag: image.tag) %></td>
         <td><%= image.repository %></td>
         <td><%= image.tag %></td>
         <td><%= number_to_human_size(image.size) %></td>
         <td><%= image.created %></td>
-        <td><%= button_to t('button.start'), images_create_container_path(repository: u(image.repository), tag: u(image.tag)), method: :post, class: 'btn btn-primary btn-sm' %></td>
+        <td><%= button_to t('button.start'), images_create_container_path(id: image.short_id, repository: image.repository, tag: image.tag), method: :post, class: 'btn btn-primary btn-sm' %></td>
       </tr>
       <%- end %>
     </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,9 +19,9 @@ JoadConsole::Application.routes.draw do
 
   controller :images do
     get 'images' => :index, as: :images_index
-    get 'images/:repository/:tag' => :show, as: :images_show
+    get 'images/:id' => :show, as: :images_show
     post 'images/create' => :create, as: :images_create
-    post 'images/:repository/:tag/create_container' => :create_container, as: :images_create_container
+    post 'images/:id/create_container' => :create_container, as: :images_create_container
     delete 'images/:repository/:tag/remove' => :remove, as: :images_remove
   end
 end


### PR DESCRIPTION
`/images/:repository/:tag` を `/images/:id` に変更してリポジトリとタグをパラメータで渡すように変更。
タグなどにドットが含まれていると、Railsのルールでフォーマットと判断されてしまうため。

例えば `/images/jenkins/1.585` の場合にタグが`1`、フォーマットが`585`というふうになる。
パス変更後では `/images/86aa47422e97?repository=jenkins&tag=1.585` になる。
